### PR TITLE
New test for movies with a year in their name

### DIFF
--- a/testdata/golden_file_078.json
+++ b/testdata/golden_file_078.json
@@ -1,0 +1,9 @@
+{
+  "Title": "Blade Runner 2049",
+  "year": 2017,
+  "resolution": "1080p",
+  "quality": "WEB-DL",
+  "codec": "H264",
+  "audio": "DD5.1",
+  "group": "FGT"
+}

--- a/testdata/input.txt
+++ b/testdata/input.txt
@@ -76,3 +76,4 @@ Ben Hur 2016 TELESYNC x264 AC3 MAXPRO
 The.Secret.Life.of.Pets.2016.HDRiP.AAC-LC.x264-LEGi0N
 [HorribleSubs] Clockwork Planet - 10 [480p].mkv
 [HorribleSubs] Detective Conan - 862 [1080p].mkv
+Blade.Runner.2049.2017.1080p.WEB-DL.DD5.1.H264-FGT-[rarbg.to]


### PR DESCRIPTION
For movies with a year in their name (like Blade Runner 2049), `go-parse-torrent-name` erroneously matches the year to the one from the title. 

I don't understand how this library works, so instead, I added a test case in case you or anyone has the time to fix this. 